### PR TITLE
Writing after seek introduces trailing 0s.

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -2883,9 +2883,20 @@ size_t FILEIO_Write (const void * buffer, size_t size, size_t count, FILEIO_OBJE
         dataWritten += writeCount;
         length -= writeCount;
     }
-
-    filePtr->size += dataWritten;
+        
+    if(filePtr->size == 0) {
+        filePtr->size += dataWritten;
+    } else {
+        uint32_t new_offset = filePtr->absoluteOffset + dataWritten;
+        if (new_offset > (filePtr->size)) {
+            filePtr->size += new_offset - filePtr->size;
+        }
+    }
+    
     filePtr->absoluteOffset += dataWritten;
+    
+    
+    
 
     return dataWritten;
 }

--- a/tests/8_3/functional_tests.c
+++ b/tests/8_3/functional_tests.c
@@ -158,6 +158,74 @@ bool SeekEnd(void){
     return true;
 }
 
+bool SeekAndWriteNotPassingEnd(void){ 
+    const char name[] = "SeekAndWriteNotPassingEnd";
+    FILEIO_OBJECT myFile;
+    
+    if(FILEIO_Open(&myFile, "TEST.TXT", FILEIO_OPEN_WRITE | FILEIO_OPEN_READ | FILEIO_OPEN_CREATE | FILEIO_OPEN_TRUNCATE) != FILEIO_RESULT_SUCCESS){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Write("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 1, 26, &myFile) != 26) {printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Seek(&myFile, 1, FILEIO_SEEK_SET) != FILEIO_RESULT_SUCCESS) {printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Write("X", 1, 1, &myFile) != 1){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Close(&myFile) != FILEIO_RESULT_SUCCESS) {printf("TEST FAILED: %s\r\n", name); return false;}    
+    if(myFile.size != 26){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Open(&myFile, "TEST.TXT", FILEIO_OPEN_WRITE | FILEIO_OPEN_READ | FILEIO_OPEN_CREATE) != FILEIO_RESULT_SUCCESS){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Seek(&myFile, 1, FILEIO_SEEK_SET) != FILEIO_RESULT_SUCCESS) {printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_GetChar(&myFile) != 'X') {printf("TEST FAILED: %s\r\n", name); return false;}
+    return true;
+}
+
+bool SeekAndWriteAtEnd(void){ 
+    const char name[] = "SeekAndWriteAtEnd";
+    FILEIO_OBJECT myFile;
+    
+    if(FILEIO_Open(&myFile, "TEST.TXT", FILEIO_OPEN_WRITE | FILEIO_OPEN_READ | FILEIO_OPEN_CREATE | FILEIO_OPEN_TRUNCATE) != FILEIO_RESULT_SUCCESS){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Write("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 1, 26, &myFile) != 26) {printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Seek(&myFile, 25, FILEIO_SEEK_SET) != FILEIO_RESULT_SUCCESS) {printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Write("X", 1, 1, &myFile) != 1){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Close(&myFile) != FILEIO_RESULT_SUCCESS) {printf("TEST FAILED: %s\r\n", name); return false;}    
+    if(myFile.size != 26){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Open(&myFile, "TEST.TXT", FILEIO_OPEN_WRITE | FILEIO_OPEN_READ | FILEIO_OPEN_CREATE) != FILEIO_RESULT_SUCCESS){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Seek(&myFile, 25, FILEIO_SEEK_SET) != FILEIO_RESULT_SUCCESS) {printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_GetChar(&myFile) != 'X') {printf("TEST FAILED: %s\r\n", name); return false;}
+
+    return true;
+}
+
+
+bool SeekAndWritePastEnd(void){ 
+    const char name[] = "SeekAndWritePastEnd";
+    FILEIO_OBJECT myFile;
+    
+    if(FILEIO_Open(&myFile, "TEST.TXT", FILEIO_OPEN_WRITE | FILEIO_OPEN_READ | FILEIO_OPEN_CREATE | FILEIO_OPEN_TRUNCATE) != FILEIO_RESULT_SUCCESS){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Write("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 1, 26, &myFile) != 26) {printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Seek(&myFile, 25, FILEIO_SEEK_SET) != FILEIO_RESULT_SUCCESS) {printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Write("12", 1, 2, &myFile) != 2){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Close(&myFile) != FILEIO_RESULT_SUCCESS) {printf("TEST FAILED: %s\r\n", name); return false;}    
+    if(myFile.size != 27){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Open(&myFile, "TEST.TXT", FILEIO_OPEN_WRITE | FILEIO_OPEN_READ | FILEIO_OPEN_CREATE) != FILEIO_RESULT_SUCCESS){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Seek(&myFile, 26, FILEIO_SEEK_SET) != FILEIO_RESULT_SUCCESS) {printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_GetChar(&myFile) != '2') {printf("TEST FAILED: %s\r\n", name); return false;}
+
+    return true;
+}
+
+bool SeekAndWritePastEnd_2(void){ 
+    const char name[] = "SeekAndWritePastEnd_2";
+    FILEIO_OBJECT myFile;
+    
+    if(FILEIO_Open(&myFile, "TEST.TXT", FILEIO_OPEN_WRITE | FILEIO_OPEN_READ | FILEIO_OPEN_CREATE | FILEIO_OPEN_TRUNCATE) != FILEIO_RESULT_SUCCESS){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Write("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 1, 26, &myFile) != 26) {printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Seek(&myFile, 25, FILEIO_SEEK_SET) != FILEIO_RESULT_SUCCESS) {printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Write("123", 1, 3, &myFile) != 3){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Close(&myFile) != FILEIO_RESULT_SUCCESS) {printf("TEST FAILED: %s\r\n", name); return false;}    
+    if(myFile.size != 28){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Open(&myFile, "TEST.TXT", FILEIO_OPEN_WRITE | FILEIO_OPEN_READ | FILEIO_OPEN_CREATE) != FILEIO_RESULT_SUCCESS){printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_Seek(&myFile, 27, FILEIO_SEEK_SET) != FILEIO_RESULT_SUCCESS) {printf("TEST FAILED: %s\r\n", name); return false;}
+    if(FILEIO_GetChar(&myFile) != '3') {printf("TEST FAILED: %s\r\n", name); return false;}
+
+    return true;
+}
+
 bool CreateMultipleDirectoriesAtOnce(void){ 
     const char name[] = "CreateMultipleDirectoriesAtOnce";
     


### PR DESCRIPTION
I've seen that my previous patch #1 was not quite correct neither for the trailing zeros nor for the deletion of cached deleted files. Regarding the latter it seems already fixed from what I see in the tests, but the former i think it still persists, so I've created this pull request with some tests and the proposed fix. Please feel free to comment me any error. Thanks!